### PR TITLE
Deleted trailing space in List command of Release module

### DIFF
--- a/RhetosCLI/Commands/Releases.cs
+++ b/RhetosCLI/Commands/Releases.cs
@@ -22,7 +22,7 @@ namespace RhetosCLI.Commands
             RhetosVersion = version;
         }
 
-        [CliCommand("List ", "List all rhetos releases")]
+        [CliCommand("List", "List all rhetos releases")]
         public void ListReleases()
         {
             var result = new List<string>();


### PR DESCRIPTION
This PR is just a tiny fix for `List` command in `Release` module. With an extra trailing space, the command will not work when we call `RhetosCLI release list`.